### PR TITLE
feat: implement winners view

### DIFF
--- a/src/components/Winners/Winners.scss
+++ b/src/components/Winners/Winners.scss
@@ -1,15 +1,2 @@
 .winner-container {
-    .winner-table {
-        border-collapse: collapse;
-
-        th,
-        td {
-            border: 1px solid #000;
-            padding: 20px;
-        }
-
-        td {
-            text-align: center;
-        }
-    }
 }

--- a/src/components/Winners/Winners.scss
+++ b/src/components/Winners/Winners.scss
@@ -1,0 +1,15 @@
+.winner-container {
+    .winner-table {
+        border-collapse: collapse;
+
+        th,
+        td {
+            border: 1px solid #000;
+            padding: 20px;
+        }
+
+        td {
+            text-align: center;
+        }
+    }
+}

--- a/src/components/Winners/Winners.tsx
+++ b/src/components/Winners/Winners.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import './Winners.scss';
+import { WinnersComponentI } from '../../interfaces/interface';
+
+export default function Winners(props: WinnersComponentI) {
+    console.log(props);
+    return (
+        <div className="winner-container">
+            <table className="winner-table">
+                <thead className="winner-table__head">
+                    <tr>
+                        <th>№</th>
+                        <th>Wins</th>
+                        <th>Best time</th>
+                    </tr>
+                </thead>
+                <tbody className="winner-table__body">
+                    {props.data.map((car) => {
+                        return (
+                            <tr>
+                                <td>{car.id}</td>
+                                <td>{car.wins}</td>
+                                <td>{car.time}</td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/src/components/Winners/Winners.tsx
+++ b/src/components/Winners/Winners.tsx
@@ -1,30 +1,33 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './Winners.scss';
-import { WinnersComponentI } from '../../interfaces/interface';
+import { CarI, WinnerI, WinnersComponentI } from '../../interfaces/interface';
+import getIdApi from '../../api/getIdApi';
+import WinnersTable from '../WinnersTable/WinnersTable';
 
 export default function Winners(props: WinnersComponentI) {
+    const [winnersData, setWinnersData] = useState<(CarI & WinnerI)[]>([]);
+
+    useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const promises = props.data.map(async (winner) => {
+                    const winnerCarData = await getIdApi('garage', winner.id);
+                    return { ...winner, ...winnerCarData } as CarI & WinnerI;
+                });
+                const winnerCarData = await Promise.all(promises);
+                setWinnersData(winnerCarData.filter(Boolean));
+            } catch (err) {
+                const error = err as Error;
+                throw new Error(error.message);
+            }
+        };
+
+        fetchData();
+    }, [props.data]);
+
     return (
         <div className="winner-container">
-            <table className="winner-table">
-                <thead className="winner-table__head">
-                    <tr>
-                        <th>№</th>
-                        <th>Wins</th>
-                        <th>Best time</th>
-                    </tr>
-                </thead>
-                <tbody className="winner-table__body">
-                    {props.data.map((car) => {
-                        return (
-                            <tr>
-                                <td>{car.id}</td>
-                                <td>{car.wins}</td>
-                                <td>{car.time}</td>
-                            </tr>
-                        );
-                    })}
-                </tbody>
-            </table>
+            <WinnersTable winnersData={winnersData} />
         </div>
     );
 }

--- a/src/components/Winners/Winners.tsx
+++ b/src/components/Winners/Winners.tsx
@@ -3,7 +3,6 @@ import './Winners.scss';
 import { WinnersComponentI } from '../../interfaces/interface';
 
 export default function Winners(props: WinnersComponentI) {
-    console.log(props);
     return (
         <div className="winner-container">
             <table className="winner-table">

--- a/src/components/Winners/Winners.tsx
+++ b/src/components/Winners/Winners.tsx
@@ -6,6 +6,24 @@ import WinnersTable from '../WinnersTable/WinnersTable';
 
 export default function Winners(props: WinnersComponentI) {
     const [winnersData, setWinnersData] = useState<(CarI & WinnerI)[]>([]);
+    const [sortConfig, setSortConfig] = useState<{
+        key: string;
+        direction: string;
+    }>({ key: '', direction: '' });
+
+    const sortOrder = (columnName: string) => {
+        let direction = '';
+        if (sortConfig.key !== columnName) direction = 'asc';
+        else {
+            if (sortConfig.direction === 'asc') direction = 'desc';
+            if (sortConfig.direction === 'desc') direction = '';
+            if (sortConfig.direction === '') direction = 'asc';
+        }
+        setSortConfig({ key: columnName, direction });
+        props.setQueryString(
+            direction && `&_sort=${columnName}&_order=${direction}`
+        );
+    };
 
     useEffect(() => {
         const fetchData = async () => {
@@ -27,7 +45,7 @@ export default function Winners(props: WinnersComponentI) {
 
     return (
         <div className="winner-container">
-            <WinnersTable winnersData={winnersData} />
+            <WinnersTable winnersData={winnersData} sortOrder={sortOrder} />
         </div>
     );
 }

--- a/src/components/WinnersTable/WinnersTable.scss
+++ b/src/components/WinnersTable/WinnersTable.scss
@@ -15,4 +15,8 @@
         width: 30px;
         height: 30px;
     }
+
+    .sort-icon {
+        cursor: pointer;
+    }
 }

--- a/src/components/WinnersTable/WinnersTable.scss
+++ b/src/components/WinnersTable/WinnersTable.scss
@@ -1,0 +1,18 @@
+.winner-table {
+    border-collapse: collapse;
+
+    th,
+    td {
+        border: 1px solid #000;
+        padding: 20px;
+    }
+
+    td {
+        text-align: center;
+    }
+
+    .car-icon {
+        width: 30px;
+        height: 30px;
+    }
+}

--- a/src/components/WinnersTable/WinnersTable.tsx
+++ b/src/components/WinnersTable/WinnersTable.tsx
@@ -2,19 +2,47 @@ import React from 'react';
 import './WinnersTable.scss';
 import { CarI, WinnerI } from '../../interfaces/interface';
 import { PiCarProfileFill } from 'react-icons/pi';
+import { TbArrowsSort } from 'react-icons/tb';
 
-type WinnersDataType = { winnersData: (WinnerI & CarI)[] };
+type WinnersDataType = {
+    winnersData: (WinnerI & CarI)[];
+    sortOrder: (columnName: string) => void;
+};
 
 export default function WinnersTable(props: WinnersDataType) {
     return (
         <table className="winner-table">
             <thead className="winner-table__head">
                 <tr>
-                    <th>№</th>
+                    <th>
+                        №{' '}
+                        <TbArrowsSort
+                            className="sort-icon"
+                            onClick={() => {
+                                props.sortOrder('id');
+                            }}
+                        />
+                    </th>
                     <th>Name</th>
                     <th>Car</th>
-                    <th>Wins</th>
-                    <th>Best time</th>
+                    <th>
+                        Wins{' '}
+                        <TbArrowsSort
+                            className="sort-icon"
+                            onClick={() => {
+                                props.sortOrder('wins');
+                            }}
+                        />
+                    </th>
+                    <th>
+                        Best time{' '}
+                        <TbArrowsSort
+                            className="sort-icon"
+                            onClick={() => {
+                                props.sortOrder('time');
+                            }}
+                        />
+                    </th>
                 </tr>
             </thead>
             <tbody className="winner-table__body">

--- a/src/components/WinnersTable/WinnersTable.tsx
+++ b/src/components/WinnersTable/WinnersTable.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import './WinnersTable.scss';
+import { CarI, WinnerI } from '../../interfaces/interface';
+import { PiCarProfileFill } from 'react-icons/pi';
+
+type WinnersDataType = { winnersData: (WinnerI & CarI)[] };
+
+export default function WinnersTable(props: WinnersDataType) {
+    return (
+        <table className="winner-table">
+            <thead className="winner-table__head">
+                <tr>
+                    <th>№</th>
+                    <th>Name</th>
+                    <th>Car</th>
+                    <th>Wins</th>
+                    <th>Best time</th>
+                </tr>
+            </thead>
+            <tbody className="winner-table__body">
+                {props.winnersData.map((data, index) => (
+                    <tr key={index}>
+                        <td>{data.id}</td>
+                        <td>{data.name}</td>
+                        <td>
+                            <PiCarProfileFill
+                                className="car-icon"
+                                color={data.color}
+                            />
+                        </td>
+                        <td>{data.wins}</td>
+                        <td>{data.time}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    );
+}

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -63,3 +63,7 @@ export interface WinnerCarI {
     name: string;
     time: number;
 }
+
+export interface WinnersComponentI {
+    data: WinnerI[];
+}

--- a/src/interfaces/interface.ts
+++ b/src/interfaces/interface.ts
@@ -66,4 +66,5 @@ export interface WinnerCarI {
 
 export interface WinnersComponentI {
     data: WinnerI[];
+    setQueryString: React.Dispatch<React.SetStateAction<string>>;
 }

--- a/src/pages/WinnersPage/WinnersPage.tsx
+++ b/src/pages/WinnersPage/WinnersPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ViewHeader from '../../components/ViewHeader/ViewHeader';
 import usePaginate from '../../utils/usePaginate';
 import Winners from '../../components/Winners/Winners';
+import Pagination from '../../components/Pagination/Pagiantion';
 
 export default function WinnersPage() {
     const pageLimit = 10;
@@ -9,7 +10,6 @@ export default function WinnersPage() {
         'winners',
         pageLimit
     );
-    console.log(data, nextPage, prevPage);
 
     return (
         <>
@@ -23,6 +23,7 @@ export default function WinnersPage() {
             <div className="content">
                 <Winners data={data} />
             </div>
+            <Pagination page={page} nextPage={nextPage} prevPage={prevPage} />
         </>
     );
 }

--- a/src/pages/WinnersPage/WinnersPage.tsx
+++ b/src/pages/WinnersPage/WinnersPage.tsx
@@ -1,14 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ViewHeader from '../../components/ViewHeader/ViewHeader';
 import usePaginate from '../../utils/usePaginate';
 import Winners from '../../components/Winners/Winners';
 import Pagination from '../../components/Pagination/Pagiantion';
 
 export default function WinnersPage() {
+    const [queryString, setQueryString] = useState('');
     const pageLimit = 10;
     const { data, page, nextPage, prevPage, total } = usePaginate(
         'winners',
-        pageLimit
+        pageLimit,
+        queryString
     );
 
     return (
@@ -21,7 +23,7 @@ export default function WinnersPage() {
                 />
             </div>
             <div className="content">
-                <Winners data={data} />
+                <Winners data={data} setQueryString={setQueryString} />
             </div>
             <Pagination page={page} nextPage={nextPage} prevPage={prevPage} />
         </>

--- a/src/pages/WinnersPage/WinnersPage.tsx
+++ b/src/pages/WinnersPage/WinnersPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ViewHeader from '../../components/ViewHeader/ViewHeader';
 import usePaginate from '../../utils/usePaginate';
+import Winners from '../../components/Winners/Winners';
 
 export default function WinnersPage() {
     const pageLimit = 10;
@@ -18,6 +19,9 @@ export default function WinnersPage() {
                     currentPageNumber={page}
                     totalItems={total}
                 />
+            </div>
+            <div className="content">
+                <Winners data={data} />
             </div>
         </>
     );

--- a/src/utils/usePaginate.tsx
+++ b/src/utils/usePaginate.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import useQueryPage from './useQueryPage';
 
-export default function usePaginate(url: string, limit: number) {
+export default function usePaginate(
+    url: string,
+    limit: number,
+    queryString?: string
+) {
     const queryPage = useQueryPage(url);
 
     const [result, setResult] = useState({
@@ -13,7 +17,9 @@ export default function usePaginate(url: string, limit: number) {
     });
 
     const refreshData = useCallback(() => {
-        fetch(`http://localhost:3000/${url}?_page=${queryPage}&_limit=${limit}`)
+        fetch(
+            `http://localhost:3000/${url}?_page=${queryPage}&_limit=${limit}${queryString || ''}`
+        )
             .then((res) => {
                 const total = parseInt(res.headers.get('X-Total-Count') || '0');
                 const page = queryPage;
@@ -32,7 +38,7 @@ export default function usePaginate(url: string, limit: number) {
             .catch((error: Error) => {
                 throw new Error(error.message);
             });
-    }, [queryPage, limit, url]);
+    }, [queryPage, limit, url, queryString]);
 
     useEffect(() => {
         refreshData();


### PR DESCRIPTION
# Pull Request - Implement Winners View

## Overview 
This pull request provides the implementation of the winners view

## Features implemented 
### Winners View (45 points)
  - [x] Display Winners (15 points): After some car wins it should be displayed at the "Winners view" table.
  - [x] Pagination for Winners (10 points): Implement pagination for the "Winners" view, with 10 winners per page.
  - [x] Winners Table (10 points): The table should include columns for the car's №, image, name, number of wins, and best time in seconds. If the same car wins more than once the number of wins should be incremented while best time should be saved only if it's better than the stored one. __(wins' count was implemented in PR https://github.com/Magadanov/async-race/pull/4 commit [feat: implement set winner car winners api](https://github.com/Magadanov/async-race/pull/4/commits/c0352ad48a8746bc258b3b4c403421f7d766a556))__
  - [x] Sorting Functionality (10 points): Allow users to sort the table by the number of wins and best time, in ascending or descending order.

## Technical Details 
  - Developed using React and Typescript
  
## Screenshots
  - Winners 
![image](https://github.com/Magadanov/async-race/assets/77725865/c5398153-3a44-4af2-9361-c5c68a722d83)